### PR TITLE
Fix an incorrect spectator check

### DIFF
--- a/LuaUI/Widgets_Evo/gui_resourceBar.lua
+++ b/LuaUI/Widgets_Evo/gui_resourceBar.lua
@@ -170,8 +170,7 @@ function widget:GameFrame(n)
 	end
 
 	if n%30 == 1 then
-		local myteam = Spring.GetMyTeamID()
-		local _, _, spectator = Spring.GetPlayerInfo(myteam)
+		local spectator = Spring.GetSpectatingState()
 		--Spring.Echo(spectator)
 		resourcePrompts = Spring.GetConfigInt("evo_resourceprompts", 1)
 		simplifiedResourceBar = Spring.GetConfigInt("evo_simplifiedresourcebar", 1)


### PR DESCRIPTION
`Spring.GetPlayerInfo` expects a player ID, not a team ID! Regardless, there's the `Spring.GetSpectatingState` callout that returns what we want directly without involving any IDs.