### PR TITLE
ezmorph won't choose locked morphs

### DIFF
--- a/LuaRules/Gadgets/unit_morph.lua
+++ b/LuaRules/Gadgets/unit_morph.lua
@@ -1069,13 +1069,19 @@ local function handleEzMorph(unitID, unitDefID, teamID, targetDefID)
 	if not morphSet then
 		return true, true
 	end
+	
+	local validMorphs = {}
  	for morphCmd, morphDef in pairs(morphSet) do
 		if (not targetDefID or morphDef.into == targetDefID)
 		and MorphRequirementsFulfilled(unitID, morphDef, teamTechLevel[teamID] or 0, TechReqList(teamID, morphDef.require)) then
-			StartMorph(unitID, unitDefID, teamID, morphDef)
-			break
+			validMorphs[#validMorphs+1] = morphDef
 		end
 	end
+
+	if #validMorphs > 0 then
+		StartMorph(unitID, unitDefID, teamID, validMorphs[math.random(1, #validMorphs)])
+	end
+
  	return true, true
 end
 


### PR DESCRIPTION
If a unit has 2 morphs and one of them is locked, ezmorph will now always prefer the available one (previously it could pick the locked one which meant the command did nothing)